### PR TITLE
Default to unmodified head in render

### DIFF
--- a/docs/api-reference/next/link.md
+++ b/docs/api-reference/next/link.md
@@ -117,9 +117,9 @@ export default NavLink
 - If you’re using [emotion](https://emotion.sh/)’s JSX pragma feature (`@jsx jsx`), you must use `passHref` even if you use an `<a>` tag directly.
 - The component should support `onClick` property to trigger navigation correctly
 
-## If the child is a function component
+## If the child is a functional component
 
-If the child of `Link` is a function component, in addition to using `passHref`, you must wrap the component in [`React.forwardRef`](https://reactjs.org/docs/react-api.html#reactforwardref):
+If the child of `Link` is a functional component, in addition to using `passHref`, you must wrap the component in [`React.forwardRef`](https://reactjs.org/docs/react-api.html#reactforwardref):
 
 ```jsx
 import Link from 'next/link'

--- a/packages/next/server/render.tsx
+++ b/packages/next/server/render.tsx
@@ -1011,7 +1011,7 @@ export async function renderToHTML(
         documentElement: (htmlProps: HtmlProps) => (
           <Document {...htmlProps} {...docProps} />
         ),
-        head: docProps.head,
+        head: docProps.head || head,
         headTags: await headTags(documentCtx),
         styles: docProps.styles,
       }


### PR DESCRIPTION
We should use the default head if we want to render externally without using Next.js, for example with Apollo. Fixes #28965

## Bug

- [x] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes
